### PR TITLE
Pin GOTOOLCHAIN to local

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: local
     strategy:
       matrix:
         go: [ stable, oldstable ]


### PR DESCRIPTION
Stop the CI action auto-upgrading, to make sure we actually work on oldstable